### PR TITLE
chore: bump android version to 1.1

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "com.fame.recipes"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 1
-        versionName "1.0"
+        versionCode 2
+        versionName "1.1"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.


### PR DESCRIPTION
Bumps Android versionCode from 1 to 2 and versionName from 1.0 to 1.1.

This triggers the `android-release` job in the publish workflow to build and release a new APK, which will include the service worker auto-update fix from #124.

Merge after #124.