### PR TITLE
feat: add hummus sin tahini recipe

### DIFF
--- a/recetas/Hummus sin tahini.md
+++ b/recetas/Hummus sin tahini.md
@@ -13,11 +13,10 @@ Para 400 g de garbanzos cocidos, ya escurridos:
 - 45-50 ml de zumo de limón
 - 1 diente de ajo mediano, sin el germen
 - 45 ml de aceite de oliva virgen extra
-- 50 g de yogur griego natural
 - ¾ de cucharadita de comino molido
 - ¾ de cucharadita rasa de sal
 - ¾ de cucharadita de aceite de sésamo tostado
-- 15-45 ml de agua fría, solo si hace falta
+- 15-60 ml de agua fría, solo si hace falta
 
 ### Para terminar
 
@@ -29,7 +28,7 @@ Para 400 g de garbanzos cocidos, ya escurridos:
 ## Elaboración
 
 1. Escurre los garbanzos, acláralos bien bajo el grifo y deja que pierdan el exceso de agua.
-2. Tritura los garbanzos con el zumo de limón, el ajo, el yogur, el comino y la sal durante 2 minutos.
+2. Tritura los garbanzos con el zumo de limón, el ajo, el comino y la sal durante 2 minutos.
 3. Baja la mezcla de las paredes del vaso, añade el aceite de oliva y el aceite de sésamo tostado, y tritura durante 1-2 minutos más.
 4. Comprueba la textura antes de añadir agua. Si queda demasiado compacto o la batidora no mueve bien la mezcla, incorpora 15 ml de agua fría y vuelve a triturar. Repite únicamente si sigue siendo necesario.
 5. Prueba y ajusta de sal, limón o comino. Si quieres reforzar el sabor tostado, añade unas gotas más de aceite de sésamo, sin superar aproximadamente 1 cucharadita en total.
@@ -38,7 +37,7 @@ Para 400 g de garbanzos cocidos, ya escurridos:
 
 ## Notas
 
-- No lleva tahini ni bicarbonato.
+- No lleva tahini, yogur ni bicarbonato.
 - El agua no es obligatoria: se utiliza únicamente para corregir la textura.
 - El aceite de sésamo tostado es muy potente; es mejor empezar con ¾ de cucharadita y ajustar después.
 - Para un hummus más denso, no añadas agua. Para una textura más ligera, incorpórala poco a poco, nunca toda de golpe.

--- a/recetas/Hummus sin tahini.md
+++ b/recetas/Hummus sin tahini.md
@@ -18,6 +18,11 @@ Para 400 g de garbanzos cocidos, ya escurridos:
 - ¾ de cucharadita de aceite de sésamo tostado
 - 15-60 ml de agua fría, solo si hace falta
 
+### Especias opcionales
+
+- ¼ de cucharadita de semillas de cilantro
+- ⅛ de cucharadita de semillas de fenogreco
+
 ### Para terminar
 
 - Aceite de oliva virgen extra
@@ -28,16 +33,19 @@ Para 400 g de garbanzos cocidos, ya escurridos:
 ## Elaboración
 
 1. Escurre los garbanzos, acláralos bien bajo el grifo y deja que pierdan el exceso de agua.
-2. Tritura los garbanzos con el zumo de limón, el ajo, el comino y la sal durante 2 minutos.
-3. Baja la mezcla de las paredes del vaso, añade el aceite de oliva y el aceite de sésamo tostado, y tritura durante 1-2 minutos más.
-4. Comprueba la textura antes de añadir agua. Si queda demasiado compacto o la batidora no mueve bien la mezcla, incorpora 15 ml de agua fría y vuelve a triturar. Repite únicamente si sigue siendo necesario.
-5. Prueba y ajusta de sal, limón o comino. Si quieres reforzar el sabor tostado, añade unas gotas más de aceite de sésamo, sin superar aproximadamente 1 cucharadita en total.
-6. Deja reposar el hummus durante 15 minutos para que se integren el ajo y las especias.
-7. Extiéndelo en un plato y termina con un chorrito de aceite de oliva, pimentón y, opcionalmente, semillas de sésamo.
+2. Si utilizas las especias opcionales, tuesta las semillas de cilantro y fenogreco en una sartén seca durante 30-60 segundos, hasta que desprendan aroma sin llegar a oscurecerse. Déjalas templar y muélelas finamente.
+3. Tritura los garbanzos con el zumo de limón, el ajo, el comino, la sal y las especias opcionales durante 2 minutos.
+4. Baja la mezcla de las paredes del vaso, añade el aceite de oliva y el aceite de sésamo tostado, y tritura durante 1-2 minutos más.
+5. Comprueba la textura antes de añadir agua. Si queda demasiado compacto o la batidora no mueve bien la mezcla, incorpora 15 ml de agua fría y vuelve a triturar. Repite únicamente si sigue siendo necesario.
+6. Prueba y ajusta de sal, limón o comino. Si quieres reforzar el sabor tostado, añade unas gotas más de aceite de sésamo, sin superar aproximadamente 1 cucharadita en total.
+7. Deja reposar el hummus durante 15 minutos para que se integren el ajo y las especias.
+8. Extiéndelo en un plato y termina con un chorrito de aceite de oliva, pimentón y, opcionalmente, semillas de sésamo.
 
 ## Notas
 
 - No lleva tahini, yogur ni bicarbonato.
+- Las semillas de cilantro aportan un matiz cítrico y cálido; el fenogreco añade un fondo tostado y ligeramente amargo. Ambas son opcionales.
+- El fenogreco domina con facilidad, por lo que conviene no superar ⅛ de cucharadita en esta cantidad.
 - El agua no es obligatoria: se utiliza únicamente para corregir la textura.
 - El aceite de sésamo tostado es muy potente; es mejor empezar con ¾ de cucharadita y ajustar después.
 - Para un hummus más denso, no añadas agua. Para una textura más ligera, incorpórala poco a poco, nunca toda de golpe.

--- a/recetas/Hummus sin tahini.md
+++ b/recetas/Hummus sin tahini.md
@@ -1,0 +1,44 @@
+---
+image: ./img/hummus-sin-tahini.svg
+tags: [aperitivo, legumbres, vegetariano, salsa]
+---
+
+# Hummus sin tahini con aceite de sésamo
+
+## Ingredientes
+
+Para 400 g de garbanzos cocidos, ya escurridos:
+
+- 400 g de garbanzos cocidos, escurridos y bien aclarados
+- 45-50 ml de zumo de limón
+- 1 diente de ajo mediano, sin el germen
+- 45 ml de aceite de oliva virgen extra
+- 50 g de yogur griego natural
+- ¾ de cucharadita de comino molido
+- ¾ de cucharadita rasa de sal
+- ¾ de cucharadita de aceite de sésamo tostado
+- 15-45 ml de agua fría, solo si hace falta
+
+### Para terminar
+
+- Aceite de oliva virgen extra
+- Pimentón dulce o picante
+- Semillas de sésamo, opcionales
+- Cayena o pimienta negra, opcionales
+
+## Elaboración
+
+1. Escurre los garbanzos, acláralos bien bajo el grifo y deja que pierdan el exceso de agua.
+2. Tritura los garbanzos con el zumo de limón, el ajo, el yogur, el comino y la sal durante 2 minutos.
+3. Baja la mezcla de las paredes del vaso, añade el aceite de oliva y el aceite de sésamo tostado, y tritura durante 1-2 minutos más.
+4. Comprueba la textura antes de añadir agua. Si queda demasiado compacto o la batidora no mueve bien la mezcla, incorpora 15 ml de agua fría y vuelve a triturar. Repite únicamente si sigue siendo necesario.
+5. Prueba y ajusta de sal, limón o comino. Si quieres reforzar el sabor tostado, añade unas gotas más de aceite de sésamo, sin superar aproximadamente 1 cucharadita en total.
+6. Deja reposar el hummus durante 15 minutos para que se integren el ajo y las especias.
+7. Extiéndelo en un plato y termina con un chorrito de aceite de oliva, pimentón y, opcionalmente, semillas de sésamo.
+
+## Notas
+
+- No lleva tahini ni bicarbonato.
+- El agua no es obligatoria: se utiliza únicamente para corregir la textura.
+- El aceite de sésamo tostado es muy potente; es mejor empezar con ¾ de cucharadita y ajustar después.
+- Para un hummus más denso, no añadas agua. Para una textura más ligera, incorpórala poco a poco, nunca toda de golpe.

--- a/recetas/img/hummus-sin-tahini.svg
+++ b/recetas/img/hummus-sin-tahini.svg
@@ -1,0 +1,108 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" role="img" aria-labelledby="title desc">
+  <title id="title">Hummus sin tahini con aceite de sésamo</title>
+  <desc id="desc">Ilustración cenital de un cuenco de hummus con aceite, garbanzos, pimentón, limón y ajo.</desc>
+  <defs>
+    <radialGradient id="bg" cx="50%" cy="42%" r="75%">
+      <stop offset="0" stop-color="#f3e6cd"/>
+      <stop offset="1" stop-color="#c7aa82"/>
+    </radialGradient>
+    <radialGradient id="ceramic" cx="40%" cy="30%" r="75%">
+      <stop offset="0" stop-color="#fffdf5"/>
+      <stop offset="0.7" stop-color="#e7dfcf"/>
+      <stop offset="1" stop-color="#b8a78c"/>
+    </radialGradient>
+    <radialGradient id="hummus" cx="45%" cy="38%" r="68%">
+      <stop offset="0" stop-color="#f1dca9"/>
+      <stop offset="0.62" stop-color="#d9b574"/>
+      <stop offset="1" stop-color="#b88b4e"/>
+    </radialGradient>
+    <linearGradient id="oil" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#dfba27" stop-opacity="0.75"/>
+      <stop offset="1" stop-color="#816811" stop-opacity="0.92"/>
+    </linearGradient>
+    <filter id="shadow" x="-30%" y="-30%" width="160%" height="160%">
+      <feGaussianBlur stdDeviation="22"/>
+    </filter>
+    <filter id="soft" x="-10%" y="-10%" width="120%" height="120%">
+      <feGaussianBlur stdDeviation="2"/>
+    </filter>
+    <pattern id="grain" width="32" height="32" patternUnits="userSpaceOnUse">
+      <circle cx="4" cy="7" r="1.2" fill="#7f6545" opacity="0.16"/>
+      <circle cx="24" cy="15" r="0.9" fill="#fff" opacity="0.24"/>
+      <circle cx="15" cy="28" r="1" fill="#896e4b" opacity="0.12"/>
+    </pattern>
+  </defs>
+
+  <rect width="1200" height="800" fill="url(#bg)"/>
+  <rect width="1200" height="800" fill="url(#grain)"/>
+  <path d="M-60 205 C230 115 350 280 625 205 S1030 95 1270 205" fill="none" stroke="#91724f" stroke-width="5" opacity="0.13"/>
+  <path d="M-30 635 C255 520 430 710 700 610 S1015 510 1260 620" fill="none" stroke="#fff" stroke-width="6" opacity="0.15"/>
+
+  <ellipse cx="610" cy="451" rx="362" ry="306" fill="#5a3b1f" opacity="0.28" filter="url(#shadow)"/>
+  <ellipse cx="600" cy="410" rx="354" ry="310" fill="url(#ceramic)" stroke="#9f8a6c" stroke-width="8"/>
+  <ellipse cx="600" cy="418" rx="307" ry="267" fill="url(#hummus)" stroke="#a77a41" stroke-width="5"/>
+
+  <g fill="none" stroke-linecap="round">
+    <ellipse cx="600" cy="418" rx="245" ry="204" stroke="#9f7138" stroke-width="13" opacity="0.45"/>
+    <ellipse cx="600" cy="418" rx="198" ry="161" stroke="#f7e6bc" stroke-width="8" opacity="0.55"/>
+    <ellipse cx="600" cy="418" rx="150" ry="117" stroke="#9b6d35" stroke-width="11" opacity="0.38"/>
+    <ellipse cx="600" cy="418" rx="104" ry="76" stroke="#f9e8bd" stroke-width="7" opacity="0.5"/>
+  </g>
+
+  <path d="M437 354 C515 287 715 295 777 385 C819 446 749 542 630 550 C520 558 435 507 443 439 C448 397 512 375 577 389 C644 404 668 465 623 493" fill="none" stroke="url(#oil)" stroke-width="20" stroke-linecap="round" filter="url(#soft)"/>
+  <ellipse cx="607" cy="424" rx="79" ry="58" fill="#a77d16" opacity="0.42"/>
+
+  <g stroke="#936329" stroke-width="3">
+    <g fill="#e8c27d"><circle cx="510" cy="360" r="17"/><path d="M502 357q9-10 17 1" fill="none"/></g>
+    <g fill="#e4bd74"><circle cx="566" cy="330" r="16"/><path d="M558 328q8-9 16 1" fill="none"/></g>
+    <g fill="#edca87"><circle cx="643" cy="342" r="18"/><path d="M634 340q9-10 18 1" fill="none"/></g>
+    <g fill="#dfb46d"><circle cx="710" cy="379" r="17"/><path d="M702 376q8-9 16 1" fill="none"/></g>
+    <g fill="#edc884"><circle cx="725" cy="450" r="18"/><path d="M716 447q9-10 18 1" fill="none"/></g>
+    <g fill="#e1b66c"><circle cx="668" cy="503" r="16"/><path d="M660 500q8-9 16 1" fill="none"/></g>
+    <g fill="#edca87"><circle cx="587" cy="516" r="18"/><path d="M578 513q9-10 18 1" fill="none"/></g>
+    <g fill="#dfb16a"><circle cx="514" cy="482" r="17"/><path d="M506 479q8-9 16 1" fill="none"/></g>
+    <g fill="#ebc37c"><circle cx="480" cy="421" r="16"/><path d="M472 418q8-9 16 1" fill="none"/></g>
+  </g>
+
+  <g fill="#a44328" opacity="0.9">
+    <circle cx="458" cy="390" r="4"/><circle cx="477" cy="457" r="3"/><circle cx="528" cy="521" r="4"/>
+    <circle cx="607" cy="548" r="3"/><circle cx="690" cy="521" r="4"/><circle cx="747" cy="461" r="3"/>
+    <circle cx="739" cy="399" r="4"/><circle cx="675" cy="323" r="3"/><circle cx="593" cy="300" r="4"/>
+    <circle cx="532" cy="340" r="3"/><circle cx="564" cy="469" r="4"/><circle cx="657" cy="397" r="3"/>
+  </g>
+  <g fill="#f7e4ae" stroke="#9b7740" stroke-width="1">
+    <ellipse cx="492" cy="391" rx="3" ry="7" transform="rotate(-24 492 391)"/>
+    <ellipse cx="539" cy="544" rx="3" ry="7" transform="rotate(31 539 544)"/>
+    <ellipse cx="699" cy="490" rx="3" ry="7" transform="rotate(-39 699 490)"/>
+    <ellipse cx="736" cy="420" rx="3" ry="7" transform="rotate(16 736 420)"/>
+    <ellipse cx="612" cy="318" rx="3" ry="7" transform="rotate(51 612 318)"/>
+    <ellipse cx="565" cy="405" rx="3" ry="7" transform="rotate(-9 565 405)"/>
+    <ellipse cx="646" cy="473" rx="3" ry="7" transform="rotate(37 646 473)"/>
+  </g>
+
+  <g transform="translate(92 85) rotate(-12 120 120)">
+    <path d="M24 173 A140 140 0 0 1 205 28 L118 130 Z" fill="#f2ce35" stroke="#b98719" stroke-width="7"/>
+    <path d="M46 160 A113 113 0 0 1 190 48 L118 130 Z" fill="#fff0a1"/>
+    <path d="M118 130L66 66M118 130L117 38M118 130L169 72" stroke="#dfbd46" stroke-width="4" opacity="0.75"/>
+  </g>
+
+  <g transform="translate(900 85)">
+    <path d="M28 65 C67 20 137 33 148 91 C156 132 117 155 72 143 C31 132 4 95 28 65Z" fill="#efe0c5" stroke="#a98a63" stroke-width="5"/>
+    <path d="M144 91l33-10-22 26z" fill="#9d774d"/>
+    <path d="M97 134 C141 101 205 129 205 179 C205 225 159 246 111 224 C67 204 59 162 97 134Z" fill="#f5e7ce" stroke="#a98a63" stroke-width="5"/>
+    <path d="M200 178l34-6-25 24z" fill="#9d774d"/>
+  </g>
+
+  <g transform="translate(80 505)">
+    <ellipse cx="83" cy="209" rx="70" ry="20" fill="#563719" opacity="0.28" filter="url(#soft)"/>
+    <rect x="32" y="40" width="102" height="170" rx="22" fill="#654126" stroke="#2e2116" stroke-width="6"/>
+    <rect x="52" y="2" width="62" height="53" rx="8" fill="#49311e" stroke="#281c12" stroke-width="5"/>
+    <rect x="46" y="103" width="74" height="71" rx="10" fill="#e5d3a8" opacity="0.93"/>
+    <g fill="#9a6d33">
+      <ellipse cx="69" cy="126" rx="4" ry="9" transform="rotate(-22 69 126)"/>
+      <ellipse cx="91" cy="145" rx="4" ry="9" transform="rotate(31 91 145)"/>
+      <ellipse cx="73" cy="159" rx="4" ry="9" transform="rotate(12 73 159)"/>
+      <ellipse cx="101" cy="120" rx="4" ry="9" transform="rotate(-35 101 120)"/>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
## Qué cambia

- Añade una receta de hummus para 400 g de garbanzos cocidos escurridos.
- La versión no lleva tahini, yogur ni bicarbonato.
- Usa aceite de sésamo tostado y AOVE, con agua únicamente como ajuste opcional de textura.
- Añade una ilustración SVG propia para la tarjeta de la receta.

## Validación

- El diff contiene únicamente el Markdown de la receta y su imagen.
- El front matter sigue el formato existente en `recetas/`.
- La imagen referenciada existe en `recetas/img/`.